### PR TITLE
Merge All Fixes for Drop Logger

### DIFF
--- a/src/drop_logger.py
+++ b/src/drop_logger.py
@@ -74,7 +74,7 @@ def filter_drops(input_list: List[str]) -> List[str]:
     return drops
 
 
-def find_new_stuff(old: str, new: str) -> str:
+async def find_new_stuff(old: str, new: str) -> str:
     # CREDIT TO SIROLAF FOR THIS FUNCTION
 	found_idx = -1
 
@@ -93,19 +93,19 @@ def find_new_stuff(old: str, new: str) -> str:
 
 async def logging_loop(client: Client):
     # TODO: Finish this loop and create a system for determining new drops
+    first_run = True
     while True:
         await asyncio.sleep(1)
 
         chat_text = await get_chat(client)
+        if first_run:
+            first_run = False
+            if chat_text:
+                temp_drops = filter_drops(chat_text.split('\n'))
+                client.latest_drops = '\n'.join(temp_drops)
         if chat_text:
             temp_drops = filter_drops(chat_text.split('\n'))
-            new_drops = ""
-            if client.latest_drops:
-                new_drops = find_new_stuff(client.latest_drops, '\n'.join(temp_drops))
-            else:
-                new_drops = '\n'.join(temp_drops)
-            #if not client.latest_drops:
-            #    client.latest_drops = '\n'.join(temp_drops)
+            new_drops = await find_new_stuff(client.latest_drops, '\n'.join(temp_drops))
 
             if new_drops:
                 client.latest_drops = '\n'.join(temp_drops)

--- a/src/drop_logger.py
+++ b/src/drop_logger.py
@@ -74,7 +74,7 @@ def filter_drops(input_list: List[str]) -> List[str]:
     return drops
 
 
-async def find_new_stuff(old: str, new: str) -> str:
+def find_new_stuff(old: str, new: str) -> str:
     # CREDIT TO SIROLAF FOR THIS FUNCTION
 	found_idx = -1
 
@@ -93,22 +93,21 @@ async def find_new_stuff(old: str, new: str) -> str:
 
 async def logging_loop(client: Client):
     # TODO: Finish this loop and create a system for determining new drops
-    first_run = True
+    chat_text = await get_chat(client)
+    if chat_text:
+        temp_drops = filter_drops(chat_text.split('\n'))
+        client.latest_drops = '\n'.join(temp_drops)
     while True:
         await asyncio.sleep(1)
 
-        chat_text = await get_chat(client)
-        if first_run:
-            first_run = False
-            if chat_text:
-                temp_drops = filter_drops(chat_text.split('\n'))
-                client.latest_drops = '\n'.join(temp_drops)
-        if chat_text:
+        if await is_visible_by_path(client, chat_window_path):
+            chat_text = await get_chat(client)
+            #if chat_text:
             temp_drops = filter_drops(chat_text.split('\n'))
-            new_drops = await find_new_stuff(client.latest_drops, '\n'.join(temp_drops))
+            new_drops = find_new_stuff(client.latest_drops, '\n'.join(temp_drops))
+            client.latest_drops = '\n'.join(temp_drops)
 
             if new_drops:
-                client.latest_drops = '\n'.join(temp_drops)
                 new_drops_list = new_drops.split('\n')
                 if len(new_drops_list) > 1 and not new_drops_list[0]:
                     new_drops_list = new_drops_list[1:]

--- a/src/drop_logger.py
+++ b/src/drop_logger.py
@@ -99,10 +99,17 @@ async def logging_loop(client: Client):
         chat_text = await get_chat(client)
         if chat_text:
             temp_drops = filter_drops(chat_text.split('\n'))
-            new_drops = find_new_stuff(client.latest_drops, '\n'.join(temp_drops))
-            if not client.latest_drops:
-                client.latest_drops = '\n'.join(temp_drops)
+            new_drops = ""
+            if client.latest_drops:
+                new_drops = find_new_stuff(client.latest_drops, '\n'.join(temp_drops))
+            else:
+                new_drops = '\n'.join(temp_drops)
+            #if not client.latest_drops:
+            #    client.latest_drops = '\n'.join(temp_drops)
 
-            elif new_drops:
+            if new_drops:
                 client.latest_drops = '\n'.join(temp_drops)
-                [logger.debug(f'{client.title} - New Drop: {drop}') for drop in new_drops.split('\n')[1:]]
+                new_drops_list = new_drops.split('\n')
+                if len(new_drops_list) > 1 and not new_drops_list[0]:
+                    new_drops_list = new_drops_list[1:]
+                [logger.debug(f'{client.title} - New Drop: {drop}') for drop in new_drops_list]


### PR DESCRIPTION
Fixes issue with the first item dropped not being logged properly.

Fixes issue when relogging. (client.latest_drops would still be set to the drop list before you relogged, meaning find_new_stuff() would return improper values).

Test having chat empty and collecting a reagent. 
Test having drops in chat, relogging, and collecting a reagent.