### PR TITLE
remove underscore stripping from command parser

### DIFF
--- a/src/command_parser.py
+++ b/src/command_parser.py
@@ -115,11 +115,6 @@ async def parse_command(clients: List[Client], command_str: str):
     all_clients = clients.copy()
     command_str = command_str.replace(', ', ',')
 
-    check_strings = ['tozone', 'to_zone', 'waitforzonechange', 'wait_for_zone_change']
-    # remove _ from command_str except for a few commands that it interferes with
-    if not any(substring in command_str for substring in check_strings):
-        command_str = command_str.replace('_', '')
-
     split_command = tokenize(command_str)
 
     if not split_command:


### PR DESCRIPTION
Fix window paths with underscores not working without expertmode

kill, sleep nothing breaks cause no underscore
client selectors don't mess around with any underscore
teleport, walkto commands either take XYZ() or a string without underscore
sendkey contains some underscores, so potentially the prev implementation of removing them would make some keys not work?
all waitfor's and potions` don't use any or were already in the exceptions
click no underscore
friendtp and entitytp entitytp is more accurate now
window paths fixed