### PR TITLE
Fixed default font size

### DIFF
--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -50,6 +50,7 @@ def manage_gui(send_queue: queue.Queue, recv_queue: queue.Queue, theme_dict, too
         pass
 
     app = QApplication(sys.argv)
+    app.setFont(QFont(gui_font if gui_font else "Segoe UI", gui_font_size if gui_font_size else 9))
 
     _vp_height = 450
 

--- a/src/gui/theme.py
+++ b/src/gui/theme.py
@@ -12,7 +12,7 @@ def compute_styles(theme: dict, font: str = None, font_size: int = None) -> dict
     bc = theme['button_color']
     tb = theme['titlebar_bg']
 
-    font_css = f" font-family: '{font}'; font-size: {font_size}pt;" if font else ""
+    font_css = (f" font-family: '{font}';" if font else "") + (f" font-size: {font_size}pt;" if font_size else "")
 
     app_style = (
         f"QWidget {{ background-color: {bg}; color: {tc};{font_css} }}"


### PR DESCRIPTION
On machines without an existing AppData/Deimos folder, the GUI font would default to the OS system font (16pt) instead of the intended 9pt.

- Call app.setFont() immediately after QApplication is created so Qt's system default font cannot bleed through before the stylesheet applies

- Decouple font-size from font-family in compute_styles so font-size is always included in the CSS even if font-family is somehow unset