### PR TITLE
Toggle side quests

### DIFF
--- a/Deimos.py
+++ b/Deimos.py
@@ -816,12 +816,12 @@ async def main():
 			while True:
 				if not freecam_status:
 					if await is_visible_by_path(client, advance_dialog_path):
-						# if await is_visible_by_path(client, decline_quest_path) and not side_quest_status:
-						# 	await client.send_key(key=Keycode.ESC)
-						# 	await asyncio.sleep(0.1)
-						# 	await client.send_key(key=Keycode.ESC)
-						# else:
-						await client.send_key(key=Keycode.SPACEBAR)
+						if await is_visible_by_path(client, decline_quest_path): # and not side_quest_status:
+							await client.send_key(key=Keycode.ESC)
+							await asyncio.sleep(0.1)
+							await client.send_key(key=Keycode.ESC)
+						else:
+							await client.send_key(key=Keycode.SPACEBAR)
 				await asyncio.sleep(0.1)
 
 		await asyncio.gather(*[async_dialogue(p) for p in walker.clients])

--- a/Deimos.py
+++ b/Deimos.py
@@ -505,11 +505,11 @@ async def main():
 	async def toggle_dialogue_hotkey():
 		global dialogue_task
 		global gui_send_queue
-		# global side_quest_status
+		global side_quest_status
 
 		if not freecam_status:
 			if dialogue_task is not None and not dialogue_task.cancelled():
-				# side_quest_status = False
+				side_quest_status = False
 				dialogue_task.cancel()
 				dialogue_task = None
 				logger.debug('Dialogue hotkey pressed, disabling auto dialogue.')
@@ -525,8 +525,12 @@ async def main():
 				dialogue_task = asyncio.create_task(try_task_coro(dialogue_loop, walker.clients, True))
 
 
-	# async def toggle_dialogue_side_quests_hotkey():
-	# 	await toggle_dialogue_hotkey(True)
+	async def toggle_dialogue_side_quests_hotkey():
+		global side_quest_status
+		side_quest_status ^= True
+		status_str = 'Enabled' if side_quest_status else 'Disabled'
+		logger.debug(f'Side quests hotkey pressed, side quest acceptance {status_str}.')
+		gui_send_queue.put(deimosgui.GUICommand(deimosgui.GUICommandType.UpdateWindow, ('SideQuestAcceptStatus', status_str)))
 
 
 
@@ -816,7 +820,7 @@ async def main():
 			while True:
 				if not freecam_status:
 					if await is_visible_by_path(client, advance_dialog_path):
-						if await is_visible_by_path(client, decline_quest_path): # and not side_quest_status:
+						if await is_visible_by_path(client, decline_quest_path) and not side_quest_status:
 							await client.send_key(key=Keycode.ESC)
 							await asyncio.sleep(0.1)
 							await client.send_key(key=Keycode.ESC)
@@ -1881,11 +1885,11 @@ async def main():
 								logger.info("This GUI option requires hooks to be active, skipping.")
 								continue
 							await friend_teleport_sync_hotkey()
-						# case deimosgui.GUICommandType.ToggleDialogueSideQuests:
-					# 	if not walker.clients:
-					# 		logger.info("This GUI option requires hooks to be active, skipping.")
-					# 		continue
-					# 	await toggle_dialogue_side_quests_hotkey()
+						case deimosgui.GUICommandType.ToggleDialogueSideQuests:
+							if not walker.clients:
+								logger.info("This GUI option requires hooks to be active, skipping.")
+								continue
+							await toggle_dialogue_side_quests_hotkey()
 						case deimosgui.GUICommandType.RebindHotkey:
 							action_id, new_key, new_mods = com.data
 							# Remove old binding from listener if active

--- a/locale/en.lang
+++ b/locale/en.lang
@@ -39,7 +39,7 @@ mass_tp=Mass TP
 xyz_sync=XYZ Sync
 x_press=X Press
 friend_tp=Friend TP
-dialogue_side_quests=+ Side Quests
+dialogue_side_quests=Accept Side Quests
 kill_tool=Kill Tool
 
 # Hotkey Manager

--- a/src/gui/tab_hotkeys.py
+++ b/src/gui/tab_hotkeys.py
@@ -33,8 +33,8 @@ def build_hotkeys_tab(ctx):
         send_queue.put(GUICommand(GUICommandType.XPress))
     def friend_tp_callback():
         send_queue.put(GUICommand(GUICommandType.FriendTeleport))
-    # def dialogue_side_quests_callback():
-    #     send_queue.put(GUICommand(GUICommandType.ToggleDialogueSideQuests))
+    def dialogue_side_quests_callback():
+        send_queue.put(GUICommand(GUICommandType.ToggleDialogueSideQuests))
 
     # --- Left panel: Hotkey Manager ---
     hk_manager = QWidget()
@@ -69,7 +69,7 @@ def build_hotkeys_tab(ctx):
             ("toggle_speed", tl('speedhack'), toggle_callback(send_queue, GUIKeys.toggle_speedhack), True, tl('speedhack'), _toggle_icons['gauge']),
             ("toggle_combat", tl('combat_toggle'), toggle_callback(send_queue, GUIKeys.toggle_combat), True, tl('combat_toggle'), _toggle_icons['combat']),
             ("toggle_dialogue", tl('dialogue'), toggle_callback(send_queue, GUIKeys.toggle_dialogue), True, tl('dialogue'), _toggle_icons['speech']),
-            # ("toggle_dialogue_side_quests", tl('dialogue_side_quests'), dialogue_side_quests_callback, False, None, _toggle_icons['speech']),
+            ("toggle_dialogue_side_quests", tl('dialogue_side_quests'), dialogue_side_quests_callback, True, 'SideQuestAccept', _toggle_icons['speech']),
             ("toggle_sigil", tl('sigil'), toggle_callback(send_queue, GUIKeys.toggle_sigil), True, tl('sigil'), _toggle_icons['bot']),
             ("toggle_questing", tl('questing'), toggle_callback(send_queue, GUIKeys.toggle_questing), True, tl('questing'), _toggle_icons['brain']),
             ("toggle_auto_pet", tl('auto_pet'), toggle_callback(send_queue, GUIKeys.toggle_auto_pet), True, tl('auto_pet'), _toggle_icons['paw']),

--- a/src/settings_manager.py
+++ b/src/settings_manager.py
@@ -80,7 +80,7 @@ DEFAULT_HOTKEYS = {
     "toggle_speed": {"key": "F5", "modifiers": []},
     "toggle_combat": {"key": "NINE", "modifiers": []},
     "toggle_dialogue": {"key": "F4", "modifiers": []},
-    # "toggle_dialogue_side_quests": {"key": "F4", "modifiers": ["SHIFT"]},
+    "toggle_dialogue_side_quests": {"key": "F4", "modifiers": ["SHIFT"]},
     "toggle_sigil": {"key": "F2", "modifiers": []},
     "toggle_questing": {"key": "F3", "modifiers": []},
     "toggle_freecam": {"key": "F1", "modifiers": []},
@@ -309,7 +309,7 @@ class DeimosSettings:
                 # Special case: dialogue also has shift variant
                 if action_id == "toggle_dialogue":
                     hotkeys["toggle_dialogue"] = {"key": value, "modifiers": []}
-                    # hotkeys["toggle_dialogue_side_quests"] = {"key": value, "modifiers": ["SHIFT"]}
+                    hotkeys["toggle_dialogue_side_quests"] = {"key": value, "modifiers": ["SHIFT"]}
                 elif action_id == "toggle_freecam":
                     hotkeys["toggle_freecam"] = {"key": value, "modifiers": []}
                     hotkeys["freecam_tp"] = {"key": value, "modifiers": ["SHIFT"]}


### PR DESCRIPTION
## Summary

Update 3.13.0 unintentionally changed the dialogue handler to accept all side quests. This fix restores the previous behavior. Side quest toggling has been re-added and some minor polish improvements have been made.

- Default hotkey is `shift` + `F4`
- Hotkey can be rebound via edit button
- Sidequest acceptance text has been changed to "Accept side quests"
- GUI text now changes to bold when enabled

## Verification

- [x] Dialogue does not auto-advance when toggled off
- [x] Side quests are declined when "Accept side quests" is disabled
- [x] Side quests are accepted when "Accept side quests" is enabled
- [x] Rebinding the hotkey works as expected
- [x] Dialogue without side quests advances normally