### PR TITLE
Fix stuck "Hooking" status for vault-launched clients

### DIFF
--- a/Deimos.py
+++ b/Deimos.py
@@ -1804,7 +1804,6 @@ async def main():
             await _init_client_attrs(nc)
             nick = launched_account_map.get(handle)
             logger.info(f"Auto-hooked vault-launched client '{nc.title}' ({nick}).")
-            _send_hooked_clients_update()
             _restart_always_on_tasks()
             _restart_active_toggle_tasks()
         except asyncio.CancelledError:
@@ -1827,6 +1826,7 @@ async def main():
         finally:
             _hooking_in_progress.discard(handle)
             _hooking_tasks.pop(handle, None)
+            _send_hooked_clients_update()
 
     async def handle_gui():
 


### PR DESCRIPTION
GUI update fired before the handle left _hooking_in_progress, so the client stayed stuck on "Hooking" after a successful hook. Moved the update into finally, after cleanup, so it fires with correct state.