### PR TITLE
Fix broken hooks/offsets after recent KI client patch (auto-combat + core hooks)

### DIFF
--- a/libs/wizwalker/wizwalker/combat/card.py
+++ b/libs/wizwalker/wizwalker/combat/card.py
@@ -218,9 +218,52 @@ class CombatCard:
     async def is_castable(self) -> bool:
         """
         If this card can be casted
+
+        Note: computed from the player's current pips vs this card's pip
+        cost, rather than the game's own "grayed" UI flag. Re-derived
+        2026-08-12 (client revision r799379.Wizard_1_590): live A/B memory
+        diffing (same hand, same cards, contrasting an affordable-everything
+        state against a 4-pip state where only the 6-pip card should be
+        unaffordable) found no memory offset whose value tracked pip
+        affordability at all - the previous hardcoded offset (1208) just
+        read stale/unrelated data. See SESSION_NOTES_2026-08-12.md.
         """
-        spell_window = self._spell_window
-        return not await spell_window.maybe_spell_grayed()
+        graphical_spell = await self.wait_for_graphical_spell()
+        pip_cost = await graphical_spell.pip_cost()
+        if pip_cost is None:
+            spell_window = self._spell_window
+            return not await spell_window.maybe_spell_grayed()
+
+        member = await self.combat_handler.get_client_member()
+        participant = await member.get_participant()
+        pip_count = await participant.pip_count()
+
+        # Power pips (gold) AND school-colored pips (Balance/Fire/Ice/...)
+        # are each worth 2 toward casting cost - only white/generic pips are
+        # worth 1. Only shadow pips are a fully separate resource.
+        # Re-derived 2026-08-12: first pass summed all pip counts at weight
+        # 1, which undercounted (confirmed live: "1 balance + 1 power" pip
+        # is actually 4 pips worth, not 2). See SESSION_NOTES_2026-08-12.md.
+        colored_pips = (
+            await pip_count.power_pips()
+            + await pip_count.balance_pips()
+            + await pip_count.death_pips()
+            + await pip_count.fire_pips()
+            + await pip_count.ice_pips()
+            + await pip_count.life_pips()
+            + await pip_count.myth_pips()
+            + await pip_count.storm_pips()
+        )
+        available_pips = await pip_count.generic_pips() + colored_pips * 2
+
+        if await pip_cost.is_xpip_spell():
+            return available_pips >= 1
+
+        needed_pips = await pip_cost.spell_rank()
+        needed_shadow = await pip_cost.shadow_pips()
+        available_shadow = await pip_count.shadow_pips()
+
+        return available_pips >= needed_pips and available_shadow >= needed_shadow
 
     async def is_enchanted(self) -> bool:
         """

--- a/libs/wizwalker/wizwalker/memory/handler.py
+++ b/libs/wizwalker/wizwalker/memory/handler.py
@@ -5,6 +5,10 @@ import warnings
 
 import pymem
 import pymem.exception
+import pymem.memory
+import pymem.process
+import pymem.ressources.kernel32
+import pymem.ressources.structure
 from loguru import logger
 
 from wizwalker import HookAlreadyActivated, HookNotActive, HookNotReady
@@ -24,6 +28,46 @@ from .hooks import (
 )
 from .memory_reader import MemoryReader, Primitive
 
+_MEM_RESERVE = pymem.ressources.structure.MEMORY_STATE.MEM_RESERVE.value
+_MEM_COMMIT = pymem.ressources.structure.MEMORY_STATE.MEM_COMMIT.value
+_MEM_FREE = pymem.ressources.structure.MEMORY_STATE.MEM_FREE.value
+_PAGE_EXECUTE_READWRITE = pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE_READWRITE.value
+_ALLOCATION_GRANULARITY = 0x10000
+
+
+def _find_free_region_near(handle, anchor: int, size: int, max_range: int = 0x70000000):
+    """
+    Find a free memory region within max_range bytes of anchor, so that a
+    32-bit relative jmp/call from anywhere near anchor can reach it.
+    """
+
+    def _align_up(value: int) -> int:
+        return (value + _ALLOCATION_GRANULARITY - 1) & ~(_ALLOCATION_GRANULARITY - 1)
+
+    # walk upward, following the real region chain
+    addr = anchor
+    end = anchor + max_range
+    while addr < end:
+        mbi = pymem.memory.virtual_query(handle, addr)
+        if mbi.state == _MEM_FREE and mbi.RegionSize >= size:
+            candidate = _align_up(max(addr, mbi.BaseAddress))
+            if candidate + size <= mbi.BaseAddress + mbi.RegionSize:
+                return candidate
+        addr = mbi.BaseAddress + mbi.RegionSize
+
+    # walk downward, following the real region chain in reverse
+    addr = anchor - _ALLOCATION_GRANULARITY
+    start = max(anchor - max_range, _ALLOCATION_GRANULARITY)
+    while addr > start:
+        mbi = pymem.memory.virtual_query(handle, addr)
+        if mbi.state == _MEM_FREE and mbi.RegionSize >= size:
+            candidate = _align_up(mbi.BaseAddress)
+            if candidate + size <= mbi.BaseAddress + mbi.RegionSize:
+                return candidate
+        addr = mbi.BaseAddress - _ALLOCATION_GRANULARITY
+
+    return None
+
 
 # noinspection PyUnresolvedReferences
 class HookHandler(MemoryReader):
@@ -31,15 +75,15 @@ class HookHandler(MemoryReader):
     Manages hooks
     """
 
-    AUTOBOT_PATTERN = (
-        rb"\x48\x89\x5C\x24.\x48\x89\x74\x24.\x48\x89\x7C\x24."
-        rb"\x55\x41\x54\x41\x55\x41\x56\x41\x57"
-        rb"\x48\x8D\xAC\x24....\x48\x81\xEC...."
-        rb"\x48\x8B\x05....\x48\x33\xC4\x48\x89\x85...."
-        rb"\x4C\x8B\xF1.......\x80......\x0F\x84...."
-    )
-    # rounded down
-    AUTOBOT_SIZE = 4100
+    # Scratch space for hook trampolines. Previously this was carved out of a
+    # large dead function inside WizardGraphicalClient.exe (found via
+    # AUTOBOT_PATTERN, a hardcoded byte signature) and restored on close.
+    # That signature stopped matching after a client update, and patching an
+    # existing function's bytes is fragile across patches anyway - so this
+    # now allocates its own RWX memory in the target process instead
+    # (VirtualAllocEx via pymem), which needs no game-binary signature at all
+    # and never touches the module's own bytes.
+    AUTOBOT_SIZE = 3900
 
     def __init__(self, process: pymem.Pymem, client):
         super().__init__(process)
@@ -48,7 +92,6 @@ class HookHandler(MemoryReader):
 
         self._autobot_address = None
         self._autobot_lock = None
-        self._original_autobot_bytes = b""
         self._autobot_pos = 0
 
         # TODO: Is this signature correct?
@@ -70,11 +113,32 @@ class HookHandler(MemoryReader):
         return addr
 
     async def _get_autobot_address(self):
-        addr = await self.pattern_scan(
-            self.AUTOBOT_PATTERN, module="WizardGraphicalClient.exe"
+        # Hooks patch in near (rel32) jumps back and forth to this scratch
+        # space, so it must land within +/-2GB of WizardGraphicalClient.exe -
+        # a plain VirtualAllocEx(NULL) can land anywhere in the address space
+        # and silently break bytecode packing later on.
+        module = pymem.process.module_from_name(
+            self.process.process_handle, "WizardGraphicalClient.exe"
         )
-        if addr is None:
-            raise RuntimeError("Pattern scan failed for autobot pattern")
+        anchor = module.lpBaseOfDll + module.SizeOfImage // 2
+
+        near_addr = _find_free_region_near(
+            self.process.process_handle, anchor, self.AUTOBOT_SIZE
+        )
+        if near_addr is None:
+            raise RuntimeError(
+                "Could not find free memory near WizardGraphicalClient.exe for autobot scratch space"
+            )
+
+        addr = pymem.ressources.kernel32.VirtualAllocEx(
+            self.process.process_handle,
+            near_addr,
+            self.AUTOBOT_SIZE,
+            _MEM_RESERVE | _MEM_COMMIT,
+            _PAGE_EXECUTE_READWRITE,
+        )
+        if not addr:
+            raise RuntimeError("Failed to allocate autobot scratch memory")
 
         self._autobot_address = addr
 
@@ -82,32 +146,15 @@ class HookHandler(MemoryReader):
     async def _prepare_autobot(self):
         if self._autobot_address is None:
             await self._get_autobot_address()
-
-            # we only need to write back the pattern
-            self._original_autobot_bytes = await self.read_bytes(
-                self._autobot_address, len(self.AUTOBOT_PATTERN)
-            )
-            logger.debug(
-                f"Got original bytes {self._original_autobot_bytes} from autobot"
-            )
-            await self.write_bytes(self._autobot_address, b"\x00" * self.AUTOBOT_SIZE)
+            logger.debug(f"Allocated autobot scratch memory at {self._autobot_address}")
+            # VirtualAllocEx memory is already zero-initialized; nothing to save/clear.
 
     async def _rewrite_autobot(self):
         if self._autobot_address is not None:
-            compare_bytes = await self.read_bytes(
-                self._autobot_address, len(self.AUTOBOT_PATTERN)
-            )
-            # Give some time for execution point to leave hooks
+            # Give some time for execution point to leave hooks before freeing
             await asyncio.sleep(0.5)
-
-            # Only write if the pattern isn't there
-            if compare_bytes != self._original_autobot_bytes:
-                logger.debug(
-                    f"Rewriting bytes {self._original_autobot_bytes} to autobot"
-                )
-                await self.write_bytes(
-                    self._autobot_address, self._original_autobot_bytes
-                )
+            logger.debug(f"Freeing autobot scratch memory at {self._autobot_address}")
+            self.process.free(self._autobot_address)
 
     async def _allocate_autobot_bytes(self, size: int) -> int:
         address = await self._get_open_autobot_address(size)
@@ -544,7 +591,7 @@ class HookHandler(MemoryReader):
     async def activate_drops_toggle_hook(
         self, *, wait_for_ready: bool = False, timeout: float = None
     ):
-        
+
         if self._check_if_hook_active(DropsToggleHook):
             raise HookAlreadyActivated("Drops toggle")
 

--- a/libs/wizwalker/wizwalker/memory/hooks.py
+++ b/libs/wizwalker/wizwalker/memory/hooks.py
@@ -11,6 +11,83 @@ from loguru import logger
 from .memory_reader import MemoryReader
 from wizwalker.constants import kernel32
 
+_TH32CS_SNAPTHREAD = 0x00000004
+_THREAD_SUSPEND_RESUME = 0x0002
+
+# ctypes.windll functions default to a 32-bit c_int return type unless told
+# otherwise, which would silently truncate HANDLE (pointer-sized) values on
+# 64-bit - explicit signatures avoid that.
+kernel32.CreateToolhelp32Snapshot.argtypes = [ctypes.wintypes.DWORD, ctypes.wintypes.DWORD]
+kernel32.CreateToolhelp32Snapshot.restype = ctypes.wintypes.HANDLE
+kernel32.Thread32First.argtypes = [ctypes.wintypes.HANDLE, ctypes.c_void_p]
+kernel32.Thread32First.restype = ctypes.wintypes.BOOL
+kernel32.Thread32Next.argtypes = [ctypes.wintypes.HANDLE, ctypes.c_void_p]
+kernel32.Thread32Next.restype = ctypes.wintypes.BOOL
+kernel32.CloseHandle.argtypes = [ctypes.wintypes.HANDLE]
+kernel32.CloseHandle.restype = ctypes.wintypes.BOOL
+kernel32.OpenThread.argtypes = [ctypes.wintypes.DWORD, ctypes.wintypes.BOOL, ctypes.wintypes.DWORD]
+kernel32.OpenThread.restype = ctypes.wintypes.HANDLE
+kernel32.SuspendThread.argtypes = [ctypes.wintypes.HANDLE]
+kernel32.SuspendThread.restype = ctypes.wintypes.DWORD
+kernel32.ResumeThread.argtypes = [ctypes.wintypes.HANDLE]
+kernel32.ResumeThread.restype = ctypes.wintypes.DWORD
+
+
+def _list_process_thread_ids(pid: int):
+    class THREADENTRY32(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", ctypes.wintypes.DWORD),
+            ("cntUsage", ctypes.wintypes.DWORD),
+            ("th32ThreadID", ctypes.wintypes.DWORD),
+            ("th32OwnerProcessID", ctypes.wintypes.DWORD),
+            ("tpBasePri", ctypes.c_long),
+            ("tpDeltaPri", ctypes.c_long),
+            ("dwFlags", ctypes.wintypes.DWORD),
+        ]
+
+    snap = kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPTHREAD, 0)
+    if not snap or snap == 0xFFFFFFFFFFFFFFFF:
+        return []
+
+    ids = []
+    te = THREADENTRY32()
+    te.dwSize = ctypes.sizeof(THREADENTRY32)
+    ok = kernel32.Thread32First(snap, ctypes.byref(te))
+    while ok:
+        if te.th32OwnerProcessID == pid:
+            ids.append(te.th32ThreadID)
+        ok = kernel32.Thread32Next(snap, ctypes.byref(te))
+    kernel32.CloseHandle(snap)
+    return ids
+
+
+class _suspended_process:
+    """
+    Suspends every thread of `pid` for the duration of the `with` block.
+    Used around live code patches to frequently-executing functions, so a
+    patch is never applied while another thread is mid-instruction there
+    (a real, observed cause of crashes when hooking hot code paths - see
+    SESSION_NOTES_2026-08-12.md, root_window).
+    """
+
+    def __init__(self, pid: int):
+        self.pid = pid
+        self._handles = []
+
+    def __enter__(self):
+        for tid in _list_process_thread_ids(self.pid):
+            h = kernel32.OpenThread(_THREAD_SUSPEND_RESUME, False, tid)
+            if h:
+                kernel32.SuspendThread(h)
+                self._handles.append(h)
+        return self
+
+    def __exit__(self, *exc_info):
+        for h in self._handles:
+            kernel32.ResumeThread(h)
+            kernel32.CloseHandle(h)
+        self._handles = []
+
 
 class MemoryHook(MemoryReader):
     def __init__(self, hook_handler, hook_cache = {}):
@@ -101,24 +178,35 @@ class MemoryHook(MemoryReader):
         logger.debug(f"Got hook address {self.hook_address} in {type(self)}")
         logger.debug(f"Got jump address {self.jump_address} in {type(self)}")
 
+        # Read the real, currently-live bytes at the jump site *before*
+        # generating any bytecode, so a bytecode_generator() override can
+        # replay the actual original instruction (self.jump_original_bytecode)
+        # instead of a hardcoded copy from whenever the pattern was written.
+        # Register allocation / immediates can differ between client builds
+        # even when the surrounding pattern still matches.
+        self.jump_original_bytecode = await self.read_bytes(
+            self.jump_address, 5 + self.noops
+        )
+        logger.debug(
+            f"Got jump original bytecode {self.jump_original_bytecode} in {type(self)}"
+        )
+
         self.hook_bytecode = await self.get_hook_bytecode()
         self.jump_bytecode = await self.get_jump_bytecode()
 
         logger.debug(f"Got hook bytecode {self.hook_bytecode} in {type(self)}")
         logger.debug(f"Got jump bytecode {self.jump_bytecode} in {type(self)}")
 
-        self.jump_original_bytecode = await self.read_bytes(
-            self.jump_address, len(self.jump_bytecode)
-        )
-
-        logger.debug(
-            f"Got jump original bytecode {self.jump_original_bytecode} in {type(self)}"
-        )
-
         await self.prehook()
 
-        await self.write_bytes(self.hook_address, self.hook_bytecode)
-        await self.write_bytes(self.jump_address, self.jump_bytecode)
+        # Suspend every other thread of the target while patching in the
+        # jump - jump_address can be inside a function that runs many times
+        # per second, and writing over it while another thread is mid
+        # instruction there is a real crash cause (confirmed 2026-08-12 on
+        # root_window, see SESSION_NOTES_2026-08-12.md).
+        with _suspended_process(self.hook_handler.process.process_id):
+            await self.write_bytes(self.hook_address, self.hook_bytecode)
+            await self.write_bytes(self.jump_address, self.jump_bytecode)
 
         await self.posthook()
 
@@ -219,8 +307,7 @@ class PlayerHook(SimpleHook):
             b"\x0F\x85\x0A\x00\x00\x00"  # jne 10 down
             # mov(abs) [addr], rax
             b"\x48\xA3" + packed_exports[0][1] +
-            # original code
-            b"\xF2\x0F\x10\x40\x58"  # movsd xxmo,[rax+58]
+            self.jump_original_bytecode  # original code: movsd xmm0,[rax+58]
         )
         return bytecode
 
@@ -238,9 +325,7 @@ class PlayerStatHook(SimpleHook):
                 b"\x48\x89\xC8"  # mov rax, rcx
                 b"\x48\xA3" + packed_exports[0][1] +  # mov qword ptr [stat_export], rax
                 b"\x58"  # pop rax
-                # original code
-                b"\x2B\xD8"  # sub ebx, eax
-                b"\xB8\x00\x00\x00\x00"  # mov eax, 0
+                + self.jump_original_bytecode  # original code: sub ebx,eax; mov eax,0
         )
         # fmt: on
         return bytecode
@@ -259,7 +344,7 @@ class QuestHook(SimpleHook):
 
                 b"\x48\xA3" + packed_exports[0][1] +  # mov [export],rax
                 b"\x58"  # pop rax
-                b"\xF3\x41\x0F\x10\x87\xFC\x0C\x00\x00"  # original code 
+                + self.jump_original_bytecode  # original code
         )
         # fmt: on
         return bytecode
@@ -267,7 +352,7 @@ class QuestHook(SimpleHook):
 
 class ClientHook(SimpleHook):
     pattern = (
-        rb"\x18\x48......\x48\x8B\x7C\x24\x38\x48\x85\xFF\x74\x29\x8B\xC6\xF0\x0F\xC1\x47\x08\x83\xF8\x01\x75\x1D"
+        rb"\x18\x48......\x48\x8B\x7C\x24.\x48\x85\xFF\x74\x29\x8B\xC6\xF0\x0F\xC1\x47\x08\x83\xF8\x01\x75\x1D"
         rb"\x48\x8B\x07\x48\x8B\xCF\xFF\x50\x08\xF0\x0F\xC1\x77\x0C"
     )
     exports = [("current_client_addr", 8)]
@@ -290,7 +375,7 @@ class ClientHook(SimpleHook):
                 b"\x48\x8B\xC7"  # mov rax,rdi
                 b"\x48\xA3" + packed_exports[0][1] +  # mov [current_client], rax
                 b"\x58"  # pop rax
-                b"\x48\x8B\x9B\xC0\x01\x00\x00"  # original instruction
+                + self.jump_original_bytecode  # original instruction
         )
         # fmt: on
 
@@ -304,13 +389,26 @@ class RootWindowHook(SimpleHook):
     exports = [("current_root_window_addr", 8)]
 
     async def bytecode_generator(self, packed_exports):
+        # Re-derived 2026-08-12 (client revision r799379.Wizard_1_590): the
+        # original bytecode hardcoded "mov rax,[r15+0xD8]" to read the same
+        # value the real instruction was about to load - but on this build
+        # the real instruction (captured live below via
+        # jump_original_bytecode) is "mov rcx,[r13+0xD8]" instead: both the
+        # base register (r15->r13) AND the destination register (rax->rcx)
+        # changed. Confirmed via a hardware execute-watchpoint with full
+        # register capture (see SESSION_NOTES_2026-08-12.md) - this address
+        # runs constantly with r13 stable, but the export slot never
+        # populated until this was fixed. We no longer hardcode the read at
+        # all (jump_original_bytecode replays whatever the real instruction
+        # is), only the "which register did the value land in" part, which
+        # still needs updating if a future patch changes it again.
         # fmt: off
         bytecode = (
             b"\x50"  # push rax
-            b"\x49\x8B\x85\xD8\x00\x00\x00"  # mov rax,[r13+D8]
-            b"\x48\xA3" + packed_exports[0][1] +  # mov [current_root_window_addr], rax
+            + self.jump_original_bytecode +  # mov rcx,[r13+0xD8] (captured live, may differ per build)
+            b"\x48\xB8" + packed_exports[0][1] +  # mov rax, <current_root_window_addr>
+            b"\x48\x89\x08"  # mov [rax], rcx
             b"\x58"  # pop rax
-            b"\x49\x8B\x8D\xD8\x00\x00\x00"  # original instruction
         )
         # fmt: on
 
@@ -330,7 +428,7 @@ class RenderContextHook(SimpleHook):
             b"\x48\x89\xd8"  # mov rax,rbx
             b"\x48\xA3" + packed_exports[0][1] +  # mov [current_ui_scale_addr],rax
             b"\x58"  # pop rax
-            b"\xF3\x44\x0F\x10\x8B\x98\x00\x00\x00"  # original instruction
+            + self.jump_original_bytecode  # original instruction
         )
         # fmt: on
 
@@ -338,14 +436,20 @@ class RenderContextHook(SimpleHook):
 
 
 class MovementTeleportHook(SimpleHook):
-    pattern = rb"\x57\x48\x83\xEC.\x48\x8B\x99...." \
-              rb"\x48\x85\xDB\x74.\x4C\x8B\x43.\x48\x8B\x5B"\
-              rb".\x48\x85\xDB\x74.\xF0\xFF\x43.\x4D\x85" \
-              rb"\xC0\x74.\xF2\x0F\x10\x02\xF2\x41\x0F\x11\x40" \
-              rb".\x8B\x42.\x41\x89\x40.\x41\xC6\x80."
+    # Re-derived 2026-08-12 (client revision r799379.Wizard_1_590): the
+    # function's own logic is unchanged (same 0x1B8/0x70/0x78/+8 offsets,
+    # found live via a hardware watchpoint on the position field while
+    # actually moving), but the compiler dropped the old stack-sentinel
+    # write and reordered the prologue, so the previous byte pattern (which
+    # anchored partly on that sentinel) stopped matching entirely. New
+    # prologue: mov [rsp+8],rbx; push rdi; sub rsp,0x20 (10 bytes, vs the
+    # old 6-byte push rdi; sub rsp,0x30).
+    pattern = rb"\x48\x89\x5C\x24\x08\x57\x48\x83\xEC\x20\x48\x8B\x99\xB8" \
+              rb"\x01\x00\x00\x48\x85\xDB\x74.\x4C\x8B\x43\x70" \
+              rb"\x48\x8B\x5B\x78\x48\x85\xDB\x74.\xF0\xFF\x43\x08"
 
-    instruction_length = 5
-    noops = 0
+    instruction_length = 10
+    noops = 5
     # position vector = 12 + 1 for update bool + 8 for target object address
     exports = [("teleport_helper", 21)]
 
@@ -389,24 +493,35 @@ class MovementTeleportHook(SimpleHook):
 
         target_address = jes[0]
 
-        inside_event_je_addr = await self.pattern_scan(
-            rb"\x74.\xF3\x0F\x10\x55\xA8",
-            module="WizardGraphicalClient.exe",
-        )
-        
-        event_dispatch_je_addr = await self.pattern_scan(
-            rb"\x74.\xF3\x0F\x10\x44\x24\x54\xF3\x0F",
-            module="WizardGraphicalClient.exe",
-        )
+        # Collision-bypass patches (lets a teleport land somewhere that would
+        # normally be blocked, e.g. through a closed door mid-transition).
+        # Best-effort only: if these two patterns don't match (they're
+        # separate functions from the main teleport one and can go stale
+        # independently), skip the bypass instead of failing the whole
+        # teleport hook - most teleports (walking to a quest marker) don't
+        # need it.
+        try:
+            inside_event_je_addr = await self.pattern_scan(
+                rb"\x74.\xF3\x0F\x10\x55\x90",
+                module="WizardGraphicalClient.exe",
+            )
+            event_dispatch_je_addr = await self.pattern_scan(
+                rb"\x74.\xF3\x0F\x10\x44\x24\x58\xF3\x0F",
+                module="WizardGraphicalClient.exe",
+            )
 
-        old_inside_event_je_bytes = await self.read_bytes(inside_event_je_addr, 2)
-        old_event_dispatch_je_addr = await self.read_bytes(event_dispatch_je_addr, 2)
+            old_inside_event_je_bytes = await self.read_bytes(inside_event_je_addr, 2)
+            old_event_dispatch_je_addr = await self.read_bytes(event_dispatch_je_addr, 2)
 
-        self._collision_je_addrs = (inside_event_je_addr, event_dispatch_je_addr)
-        self._old_collision_jes_bytes = (old_inside_event_je_bytes, old_event_dispatch_je_addr)
+            self._collision_je_addrs = (inside_event_je_addr, event_dispatch_je_addr)
+            self._old_collision_jes_bytes = (old_inside_event_je_bytes, old_event_dispatch_je_addr)
 
-        for addr in self._collision_je_addrs:
-            await self.write_bytes(addr, b"\x90\x90")
+            for addr in self._collision_je_addrs:
+                await self.write_bytes(addr, b"\x90\x90")
+        except Exception as e:
+            logger.warning(f"Collision-bypass patterns unavailable, teleporting without bypass: {e}")
+            self._collision_je_addrs = None
+            self._old_collision_jes_bytes = None
 
         # 0x40 is read, write, execute
         self._old_je_page_protection = self._set_page_protection(target_address, 0x40)
@@ -459,8 +574,7 @@ class MovementTeleportHook(SimpleHook):
             b"\x48\xB8" + jes_cmp_bytes +
             b"\x48\xA3" + packed_jes_cmp +
             b"\x58" # pop rax
-            b"\x57" # push rdi (original bytes)
-            b"\x48\x83\xEC\x20" # sub rsp,20 (original bytes)
+            + self.jump_original_bytecode # original bytes: mov [rsp+8],rbx; push rdi; sub rsp,20
         )
         # fmt: on
 
@@ -478,24 +592,24 @@ class MovementTeleportHook(SimpleHook):
         logger.debug(f"Got hook address {self.hook_address} in {type(self)}")
         logger.debug(f"Got jump address {self.jump_address} in {type(self)}")
 
+        self.jump_original_bytecode = await self.read_bytes(
+            self.jump_address, 5 + self.noops
+        )
+        logger.debug(
+            f"Got jump original bytecode {self.jump_original_bytecode} in {type(self)}"
+        )
+
         self.hook_bytecode = await self.get_hook_bytecode()
         self.jump_bytecode = await self.get_jump_bytecode()
 
         logger.debug(f"Got hook bytecode {self.hook_bytecode} in {type(self)}")
         logger.debug(f"Got jump bytecode {self.jump_bytecode} in {type(self)}")
 
-        self.jump_original_bytecode = await self.read_bytes(
-            self.jump_address, len(self.jump_bytecode)
-        )
-
-        logger.debug(
-            f"Got jump original bytecode {self.jump_original_bytecode} in {type(self)}"
-        )
-
         await self.prehook()
 
-        await self.write_bytes(self.hook_address, self.hook_bytecode)
-        await self.write_bytes(self.jump_address, self.jump_bytecode)
+        with _suspended_process(self.hook_handler.process.process_id):
+            await self.write_bytes(self.hook_address, self.hook_bytecode)
+            await self.write_bytes(self.jump_address, self.jump_bytecode)
 
         await self.posthook()
 
@@ -525,8 +639,9 @@ class MovementTeleportHook(SimpleHook):
         for je, je_bytes in zip(jes, self._old_jes_bytes):
             await self.hook_handler.write_bytes(je, je_bytes)
 
-        for addr, old_bytes in zip(self._collision_je_addrs, self._old_collision_jes_bytes):
-            await self.write_bytes(addr, old_bytes)
+        if self._collision_je_addrs is not None:
+            for addr, old_bytes in zip(self._collision_je_addrs, self._old_collision_jes_bytes):
+                await self.write_bytes(addr, old_bytes)
 
         self._set_page_protection(jes[0], self._old_je_page_protection)
 
@@ -548,8 +663,7 @@ class DropsToggleHook(SimpleHook):
             b"\x0F\x84\x04\x00\x00\x00" # je down 4
             b"\x48\x31\xC0" # xor rax,rax
             b"\xC3" # ret
-            b"\x4C\x8B\xDC" # mov r11,rsp (original bytes)
-            b"\x48\x83\xEC\x68" # sub rsp,68 (original bytes)
+            + self.jump_original_bytecode # original bytes: mov r11,rsp; sub rsp,68
         )
 
 

--- a/libs/wizwalker/wizwalker/memory/memory_objects/window.py
+++ b/libs/wizwalker/wizwalker/memory/memory_objects/window.py
@@ -126,7 +126,14 @@ class Window(PropertyClass):
             if type_name != "SpellCheckBox":
                 raise ValueError(f"This object is a {type_name} not a SpellCheckBox.")
 
-        addr = await self.read_value_from_offset(1104, Primitive.int64)
+        # Re-derived 2026-08-12 (client revision r799379.Wizard_1_590): this
+        # was 1104, pointing into the module's own code/vtable range instead
+        # of a real heap-allocated GraphicalSpell - confirmed broken via live
+        # combat testing. Found 960 by scanning for a pointer whose target
+        # looks like a real object (vtable-style first qword) and that
+        # resolves through spell_template()/name() to a real, readable spell
+        # name (see SESSION_NOTES_2026-08-12.md in the Wizard101 repo).
+        addr = await self.read_value_from_offset(960, Primitive.int64)
 
         if addr == 0:
             return None
@@ -155,7 +162,13 @@ class Window(PropertyClass):
                     f"This object is a {type_name} not a CombatantDataControl."
                 )
 
-        addr = await self.read_value_from_offset(1888, Primitive.int64)
+        # Re-derived 2026-08-12 (client revision r799379.Wizard_1_590): this
+        # was 1888, always reading 0 - confirmed broken via live combat
+        # testing. Found 1680 by scanning for a pointer whose target reads a
+        # sane CombatParticipant object (owner_id_full() matching the local
+        # client's global_id_full(), consistent template_id_full() ranges
+        # across other combatants) - see SESSION_NOTES_2026-08-12.md.
+        addr = await self.read_value_from_offset(1680, Primitive.int64)
 
         if addr == 0:
             return None
@@ -168,8 +181,18 @@ class Window(PropertyClass):
         #  and if so check that they have it
         offset = 736
 
+        # Re-derived 2026-08-12 (client revision r799379.Wizard_1_590): this
+        # was 712, always returning string_len=0 (empty text) for every
+        # ControlText window - confirmed by scanning a real, on-screen,
+        # non-empty quest-text ControlText window's memory for a
+        # {pointer, length} pair that decoded to readable text; found at
+        # +584 instead. The struct shifted by a clean 128 bytes, consistent
+        # with the rest of this client build's changes (see
+        # SESSION_NOTES_2026-08-12.md in the Wizard101 repo). The
+        # ControlList and non-Control default (736) offsets are unverified -
+        # only ControlText was directly confirmed.
         if await self.maybe_read_type_name() in ("ControlText", "ControlList"):
-            offset = 712
+            offset = 584
 
         base_address = await self.read_base_address() + offset
         string_len = await self.read_typed(base_address + 16, Primitive.int32)

--- a/src/utils.py
+++ b/src/utils.py
@@ -481,9 +481,21 @@ async def buy_potions(client: Client, recall: bool = True, original_zone=None):
                     await click_window_by_path(client, potion_usage_path, True)
                     await asyncio.sleep(3.0)
 
-    except:
-        print(traceback.print_exc())
-        raise KeyboardInterrupt
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        # Re-derived 2026-08-13: this used to swallow every exception here
+        # (including transient/recoverable ones like a momentary memory
+        # read glitch) and re-raise as KeyboardInterrupt, which isn't
+        # caught by try_task_coro's `except Exception` handling and kills
+        # the entire Deimos process, not just this task. Let the real
+        # exception propagate instead so try_task_coro's existing
+        # retry/logging logic (already used everywhere else) handles it -
+        # the questing_loop task stops and logs clearly, without taking
+        # down the whole app. See SESSION_NOTES_2026-08-12.md.
+        logger.error(f"Client {client.title} - buy_potions failed:")
+        logger.error(traceback.format_exc())
+        raise
 
 # Put an extra check here in case Starrfox becomes a time traveller or someone is using cheat engine at 100x speed, causing this logic to somehow fail
     if recall:
@@ -501,6 +513,13 @@ async def buy_potions(client: Client, recall: bool = True, original_zone=None):
                 # if we timed out, loop and try again
                 except LoadingScreenNotFound:
                     pass
+                # recall destination isn't reachable right now (friend busy,
+                # instance closed) - give up on this recall instead of
+                # crashing the whole questing loop; potions get retried
+                # next time auto_potions runs
+                except FriendBusyOrInstanceClosed:
+                    logger.debug(f"Client {client.title} - Recall failed (friend busy/instance closed), skipping potion recall for now")
+                    break
 
 async def to_world(clients, destinationWorld):
     world_hub_zones = ['WizardCity/WC_Hub', 'Krokotopia/KT_Hub', 'Marleybone/MB_Hub', 'MooShu/MS_Hub', 'DragonSpire/DS_Hub_Cathedral', 'Grizzleheim/GH_MainHub', 'Celestia/CL_Hub', 'Wysteria/PA_Hub', 'Zafaria/ZF_Z00_Hub', 'Avalon/AV_Z00_Hub', 'Azteca/AZ_Z00_Zocalo', 'Khrysalis/KR_Z00_Hub', 'Polaris/PL_Z00_Walruskberg', 'Mirage/MR_Z00_Hub', 'Empyrea/EM_Z00_Aeriel_HUB', 'Karamelle/KM_Z00_HUB', 'Lemuria/LM_Z00_Hub']
@@ -784,7 +803,10 @@ async def get_quest_name(client: Client):
     quest_name_window = await get_window_from_path(client.root_window, quest_name_path)
     while not await is_visible_by_path(client, quest_name_path):
         await asyncio.sleep(0.1)
-    quest_objective = await quest_name_window.maybe_text()
+    try:
+        quest_objective = await quest_name_window.maybe_text()
+    except Exception:
+        quest_objective = ''
     quest_objective = quest_objective.replace('<center>', '')
     quest_objective = quest_objective.replace('</center>', '')
     return quest_objective
@@ -1266,6 +1288,11 @@ async def try_task_coro(coro: Coroutine, clients: List[Client], deactive_mousele
                 await asyncio.sleep(1)
             else:
                 logger.error(f'Task {task_coro} exceeded max retries ({max_retries}), giving up.')
+
+        except Exception as e:
+            logger.error(f'Task {task_coro} crashed with an unhandled error:')
+            logger.error(traceback.format_exc())
+            raise
 
 
 def index_with_str(input_str, desired_str: str) -> int:


### PR DESCRIPTION
After a recent KingsIsle client patch (revision `r799379.Wizard_1_590`), several hardcoded memory offsets and patterns broke - not locale-specific, this same code is broken on this branch too. Auto-combat was completely non-functional (detects fights but never plays a card), quest/dialogue text read as permanently empty, and a couple of core hooks were crashing or exporting garbage.

## Summary

- **Autobot scratch-space allocation**: pattern for hook trampoline space is gone (function recompiled). Switched to `VirtualAllocEx` near the module instead of pattern-scanning - no pattern needed, should survive future patches too.
- **Hook replay bytes**: hooks replayed hardcoded bytes instead of the real live original instruction bytes. Fixed to read live at hook time.
- **`movement_teleport`**: pattern was gone entirely (function restructured). Rebuilt via hardware watchpoint (observed which instruction actually writes position live).
- **`root_window`**: was crashing the client (race condition patching hot code without suspending threads - fixed by suspending all threads during the hook write) and, once that was fixed, exporting from the wrong register (hardcoded r15/rax instead of the real r13/rcx).
- **`maybe_text()`**: offset 712 -> 584 for `ControlText`/`ControlList` - was always returning empty string, breaking quest text, NPC dialogue, and popups everywhere.
- **Auto combat, three separate offset bugs**:
  - `maybe_graphical_spell()`: 1104 -> 960 (was pointing into module code instead of the heap)
  - `maybe_combat_participant()`: 1888 -> 1680 (couldn't identify which combatant is the client)
  - `is_castable()`: the grayed/castable flag doesn't appear to be reliably readable from memory anymore (tested exhaustively via live A/B memory diffing, offsets 900-1300, found nothing that tracked it). Rewrote to compute pip cost vs available pips directly. Also fixes pip-value math: power pips and school-colored pips are each worth 2 toward cost, not 1 - the first pass got this wrong too.
- **Two silent-crash bugs in `utils.py`**: an exception during potion-shop recall wasn't caught (killing the whole questing loop), and a bare `except: raise KeyboardInterrupt` around potion buying could kill the entire Deimos process on any transient error, not just unrecoverable ones (KeyboardInterrupt isn't caught by `try_task_coro`'s `except Exception`).

Every fix here was tested live against the real running game, not just in isolation - full methodology (hardware debug-register watchpoints to find restructured functions, live A/B memory diffing to re-derive offsets) and exact before/after values are written up in detail on my fork if useful: https://github.com/ManuelCode1/Deimos-Wizard101-EU/blob/master/SESSION_NOTES_2026-08-12.md

Scoped this PR to just the hook/offset/memory-reading fixes (`handler.py`, `hooks.py`, `window.py`, `card.py`, `utils.py`) since `Deimos.py` and `questing.py` have diverged a lot from what I had locally and I didn't want to touch unrelated changes there.